### PR TITLE
Truly Modular Definitions

### DIFF
--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/ApiHandler/HeartApiMethods.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/ApiHandler/HeartApiMethods.cs
@@ -38,6 +38,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.ApiHandler
                 ["GetProjectileDefinition"] = new Func<int, byte[]>(GetProjectileDefinition), // TODO: Allow projectiles/weapons to have independent definitions
                 ["RegisterProjectileDefinition"] = new Func<byte[], int>(RegisterProjectileDefinition),
                 ["UpdateProjectileDefinition"] = new Func<int, byte[], bool>(UpdateProjectileDefinition),
+                ["RemoveProjectileDefinition"] = new Action<int>(ProjectileDefinitionManager.RemoveDefinition),
 
                 // Weapon Generics
                 ["BlockHasWeapon"] = new Func<MyEntity, bool>(HasWeapon),
@@ -46,6 +47,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.ApiHandler
                 ["GetWeaponDefinition"] = new Func<string, byte[]>(GetWeaponDefinition),
                 ["RegisterWeaponDefinition"] = new Func<byte[], bool>(RegisterWeaponDefinition),
                 ["UpdateWeaponDefinition"] = new Func<byte[], bool>(UpdateWeaponDefinition),
+                ["RemoveWeaponDefinition"] = new Action<string>(WeaponDefinitionManager.RemoveDefinition),
 
                 // Standard
                 ["LogWriteLine"] = new Action<string>(HeartData.I.Log.Log),

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/ApiHandler/HeartApiMethods.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/ApiHandler/HeartApiMethods.cs
@@ -118,28 +118,22 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.ApiHandler
         }
         public byte[] GetProjectileDefinition(int definitionId)
         {
-            ProjectileDefinitionBase def = ProjectileDefinitionManager.GetDefinition(definitionId);
+            var def = ProjectileDefinitionManager.GetSerializedDefinition(definitionId);
             if (def == null)
                 return null;
-            return MyAPIGateway.Utilities.SerializeToBinary(def);
+            return def;
         }
         public int RegisterProjectileDefinition(byte[] serialized)
         {
             if (serialized == null)
                 return -1;
-            ProjectileDefinitionBase def = MyAPIGateway.Utilities.SerializeFromBinary<ProjectileDefinitionBase>(serialized);
-            if (def == null)
-                return -1;
-            return ProjectileDefinitionManager.RegisterModApiDefinition(def);
+            return ProjectileDefinitionManager.RegisterModApiDefinition(serialized);
         }
         public bool UpdateProjectileDefinition(int definitionId, byte[] serialized)
         {
             if (serialized == null)
                 return false;
-            ProjectileDefinitionBase def = MyAPIGateway.Utilities.SerializeFromBinary<ProjectileDefinitionBase>(serialized);
-            if (def == null)
-                return false;
-            return ProjectileDefinitionManager.ReplaceDefinition(definitionId, def, true);
+            return ProjectileDefinitionManager.ReplaceDefinition(definitionId, serialized, true);
         }
         #endregion
 
@@ -159,7 +153,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.ApiHandler
         public byte[] GetWeaponDefinition(string subtype)
         {
             if (WeaponDefinitionManager.HasDefinition(subtype))
-                return MyAPIGateway.Utilities.SerializeToBinary(WeaponDefinitionManager.GetDefinition(subtype));
+                return WeaponDefinitionManager.GetSerializedDefinition(subtype);
             return null;
         }
 
@@ -168,14 +162,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.ApiHandler
             if (definition == null || definition.Length == 0)
                 return false;
 
-            WeaponDefinitionBase weaponDef = MyAPIGateway.Utilities.SerializeFromBinary<WeaponDefinitionBase>(definition);
-            if (definition == null)
-            {
-                SoftHandle.RaiseException("Invalid weapon definition!");
-                return false;
-            }
-
-            return WeaponDefinitionManager.RegisterModApiDefinition(weaponDef);
+            return WeaponDefinitionManager.RegisterModApiDefinition(definition);
         }
 
         public bool UpdateWeaponDefinition(byte[] definition)
@@ -183,14 +170,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.ApiHandler
             if (definition == null || definition.Length == 0)
                 return false;
 
-            WeaponDefinitionBase weaponDef = MyAPIGateway.Utilities.SerializeFromBinary<WeaponDefinitionBase>(definition);
-            if (definition == null)
-            {
-                SoftHandle.RaiseException("Invalid weapon definition!");
-                return false;
-            }
-
-            return WeaponDefinitionManager.UpdateDefinition(weaponDef);
+            return WeaponDefinitionManager.UpdateDefinition(definition);
         }
         #endregion
 

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/StandardClasses/DefinitionContainer.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/StandardClasses/DefinitionContainer.cs
@@ -8,8 +8,8 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions.StandardClasses
     internal class DefinitionContainer
     {
         [ProtoMember(1)]
-        public WeaponDefinitionBase[] WeaponDefs { get; set; }
+        public byte[][] WeaponDefs { get; set; }
         [ProtoMember(2)]
-        public ProjectileDefinitionBase[] AmmoDefs { get; set; }
+        public byte[][] AmmoDefs { get; set; }
     }
 }

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/n_ProjectileDefinitionIdSync.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Definitions/n_ProjectileDefinitionIdSync.cs
@@ -26,10 +26,10 @@ namespace Heart_Module.Data.Scripts.HeartModule.Definitions
         {
             if (MyAPIGateway.Session.IsServer)
                 return;
-            HeartData.I.Log.Log("I'M SYNCIIIING");
+            HeartData.I.Log.Log("Syncing projectile definition " + Name + " to " + Id);
             if (Serialized != null)
                 ProjectileDefinitionManager.RegisterDefinition(MyAPIGateway.Utilities.SerializeFromBinary<ProjectileDefinitionBase>(Serialized));
-            ProjectileDefinitionManager.ReorderDefinitions(Name, Id);
+            //ProjectileDefinitionManager.ReorderDefinitions(Name, Id);
         }
     }
 }

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Projectiles/ProjectileDefinitionManager.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Projectiles/ProjectileDefinitionManager.cs
@@ -2,6 +2,7 @@
 using Heart_Module.Data.Scripts.HeartModule.Projectiles.StandardClasses;
 using Sandbox.ModAPI;
 using System.Collections.Generic;
+using VRage.Utils;
 
 namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
 {
@@ -13,26 +14,6 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
         public static ProjectileDefinitionManager I;
         private List<ProjectileDefinitionBase> Definitions = new List<ProjectileDefinitionBase>(); // TODO: Store serialized versions of definitions in case of modded functionality
         private Dictionary<string, int> DefinitionNamePairs = new Dictionary<string, int>();
-
-        /// <summary>
-        /// Changes the ID of a projectile definition. If the ID is already occupied, swaps the two definitions. DO NOT CALL ON SERVER!
-        /// Unused.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="newId"></param>
-        public static void ReorderDefinitions(string name, int newId)
-        {
-            //if (!HasDefinition(name)) return;
-            //int oldId = GetId(name);
-            //if (oldId == newId) return;
-            //ProjectileDefinitionBase bufferDefinition = GetDefinition(name);
-            //while (!HasDefinition(newId))
-            //    I.Definitions.Add(null);
-            //I.Definitions[oldId] = GetDefinition(newId);
-            //I.DefinitionNamePairs[I.Definitions[oldId].Name] = newId;
-            //I.Definitions[newId] = bufferDefinition;
-            //I.DefinitionNamePairs[name] = newId;
-        }
 
         public static ProjectileDefinitionBase GetDefinition(int id)
         {
@@ -121,6 +102,18 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
                     MyAPIGateway.Utilities.SerializeToBinary(definition)
                     ));
             return true;
+        }
+
+        public static void RemoveDefinition(int definitionId)
+        {
+            if (!HasDefinition(definitionId))
+                return;
+
+            var definition = I.Definitions[definitionId];
+            I.DefinitionNamePairs.Remove(definition.Name);
+            I.Definitions.RemoveAt(definitionId);
+
+            HeartData.I.Log.Log($"Removed ammo definition " + definitionId);
         }
 
         public static int DefinitionCount()

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Projectiles/ProjectileDefinitionManager.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Projectiles/ProjectileDefinitionManager.cs
@@ -13,6 +13,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
     {
         public static ProjectileDefinitionManager I;
         private List<ProjectileDefinitionBase> Definitions = new List<ProjectileDefinitionBase>(); // TODO: Store serialized versions of definitions in case of modded functionality
+        private List<byte[]> SerializedDefinitions = new List<byte[]>();
         private Dictionary<string, int> DefinitionNamePairs = new Dictionary<string, int>();
 
         public static ProjectileDefinitionBase GetDefinition(int id)
@@ -23,9 +24,22 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
                 return null;
         }
 
+        public static byte[] GetSerializedDefinition(int id)
+        {
+            if (HasDefinition(id))
+                return I.SerializedDefinitions[id];
+            else
+                return null;
+        }
+
         public static ProjectileDefinitionBase GetDefinition(string name)
         {
             return GetDefinition(GetId(name));
+        }
+
+        public static byte[] GetSerializedDefinition(string name)
+        {
+            return GetSerializedDefinition(GetId(name));
         }
 
         public static int GetId(string definitionName)
@@ -57,11 +71,9 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
         /// </summary>
         /// <param name="definition"></param>
         /// <returns></returns>
-        public static int RegisterModApiDefinition(ProjectileDefinitionBase definition)
+        public static int RegisterModApiDefinition(byte[] serializedDefinition)
         {
-            if (HasDefinition(definition.Name))
-                throw new System.Exception("Attempted to assign ProjectileDefinition to existing ID!");
-            return RegisterDefinition(definition, true);
+            return RegisterDefinition(serializedDefinition);
         }
 
         /// <summary>
@@ -70,7 +82,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
         /// <param name="definition"></param>
         /// <param name="syncToClients"></param>
         /// <returns></returns>
-        public static int RegisterDefinition(ProjectileDefinitionBase definition, bool syncToClients = false)
+        public static int RegisterDefinition(ProjectileDefinitionBase definition)
         {
             if (I.DefinitionNamePairs.ContainsKey(definition.Name))
             {
@@ -78,32 +90,91 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
                 return -1;
             }
 
+            var serializedDefinition = MyAPIGateway.Utilities.SerializeToBinary(definition);
+
             I.Definitions.Add(definition);
+            I.SerializedDefinitions.Add(serializedDefinition);
             I.DefinitionNamePairs.Add(definition.Name, I.Definitions.Count - 1);
             if (MyAPIGateway.Session.IsServer)
                 HeartData.I.Net.SendToEveryone(new n_ProjectileDefinitionIdSync(
                     I.Definitions.Count - 1,
                     definition.Name,
-                    syncToClients ? MyAPIGateway.Utilities.SerializeToBinary(definition) : null
+                    serializedDefinition
                     ));
-            HeartData.I.Log.Log($"Registered projectile definition {definition.Name} for ID {I.Definitions.Count - 1}.");
+            HeartData.I.Log.Log($"Registered class projectile definition {definition.Name} for ID {I.Definitions.Count - 1}.");
             return I.Definitions.Count - 1;
+        }
+
+        /// <summary>
+        /// Registers a projectile definition.
+        /// </summary>
+        /// <param name="definition"></param>
+        /// <param name="syncToClients"></param>
+        /// <returns></returns>
+        public static int RegisterDefinition(byte[] serializedDefinition)
+        {
+            var definition = MyAPIGateway.Utilities.SerializeFromBinary<ProjectileDefinitionBase>(serializedDefinition);
+            if (I.DefinitionNamePairs.ContainsKey(definition.Name))
+            {
+                HeartData.I.Log.Log($"Duplicate ammo definition {definition.Name}! Skipping...");
+                return -1;
+            }
+
+            I.Definitions.Add(definition);
+            I.SerializedDefinitions.Add(serializedDefinition);
+            I.DefinitionNamePairs.Add(definition.Name, I.Definitions.Count - 1);
+            if (MyAPIGateway.Session.IsServer)
+                HeartData.I.Net.SendToEveryone(new n_ProjectileDefinitionIdSync(
+                    I.Definitions.Count - 1,
+                    definition.Name,
+                    serializedDefinition
+                    ));
+            HeartData.I.Log.Log($"Registered binary projectile definition {definition.Name} for ID {I.Definitions.Count - 1}.");
+            return I.Definitions.Count - 1;
+        }
+
+        public static bool ReplaceDefinition(int definitionId, byte[] serializedDefinition, bool syncToClients = false)
+        {
+            if (!HasDefinition(definitionId))
+                return false;
+            var definition = MyAPIGateway.Utilities.SerializeFromBinary<ProjectileDefinitionBase>(serializedDefinition);
+
+            I.Definitions[definitionId] = definition;
+            I.SerializedDefinitions[definitionId] = serializedDefinition;
+            if (MyAPIGateway.Session.IsServer && syncToClients)
+                HeartData.I.Net.SendToEveryone(new n_ProjectileDefinitionIdSync(
+                    definitionId,
+                    definition.Name,
+                    serializedDefinition
+                    ));
+
+            HeartData.I.Log.Log($"Updated binary projectile definition {definition.Name} for ID {definitionId}");
+            return true;
         }
 
         public static bool ReplaceDefinition(int definitionId, ProjectileDefinitionBase definition, bool syncToClients = false)
         {
             if (!HasDefinition(definitionId))
                 return false;
+            var serializedDefinition = MyAPIGateway.Utilities.SerializeToBinary(definition);
+
             I.Definitions[definitionId] = definition;
+            I.SerializedDefinitions[definitionId] = serializedDefinition;
             if (MyAPIGateway.Session.IsServer && syncToClients)
                 HeartData.I.Net.SendToEveryone(new n_ProjectileDefinitionIdSync(
                     definitionId,
                     definition.Name,
-                    MyAPIGateway.Utilities.SerializeToBinary(definition)
+                    serializedDefinition
                     ));
+
+            HeartData.I.Log.Log($"Updated class projectile definition {definition.Name} for ID {definitionId}");
             return true;
         }
 
+        /// <summary>
+        /// TODO: Does not properly remove ammos!
+        /// </summary>
+        /// <param name="definitionId"></param>
         public static void RemoveDefinition(int definitionId)
         {
             if (!HasDefinition(definitionId))
@@ -111,7 +182,8 @@ namespace Heart_Module.Data.Scripts.HeartModule.Projectiles
 
             var definition = I.Definitions[definitionId];
             I.DefinitionNamePairs.Remove(definition.Name);
-            I.Definitions.RemoveAt(definitionId);
+            I.Definitions[definitionId] = null;
+            I.SerializedDefinitions[definitionId] = null;
 
             HeartData.I.Log.Log($"Removed ammo definition " + definitionId);
         }

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/UserInterface/ReloadIndicators/ReloadWindow.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/UserInterface/ReloadIndicators/ReloadWindow.cs
@@ -2,9 +2,11 @@
 using Heart_Module.Data.Scripts.HeartModule.Projectiles.StandardClasses;
 using Heart_Module.Data.Scripts.HeartModule.Weapons;
 using RichHudFramework.UI;
+using Sandbox.ModAPI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using VRage.Game.ModAPI;
 using VRageMath;
 using YourName.ModName.Data.Scripts.HeartModule.Weapons.Setup.Adding;
 
@@ -71,7 +73,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.UserInterface.ReloadIndicators
         {
             if (!weapon.SorterWep.ShowInTerminal) // Hide weapons that aren't shown in terminal
                 return;
-
+            
             //MyAPIGateway.Utilities.ShowMessage("OCF", "Show weapon " + weapon.Id);
             var entry = GetEntry(weapon.Id);
             if (entry == null)

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Weapons/WeaponDefinitionManager.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Weapons/WeaponDefinitionManager.cs
@@ -1,8 +1,9 @@
 ﻿using Heart_Module.Data.Scripts.HeartModule.ErrorHandler;
 using Heart_Module.Data.Scripts.HeartModule.Weapons.StandardClasses;
-using Sandbox.Game.GUI.DebugInputComponents;
+using Sandbox.ModAPI;
 using System.Collections.Generic;
 using System.Linq;
+using VRage.Game.ModAPI;
 
 namespace Heart_Module.Data.Scripts.HeartModule.Weapons
 {
@@ -15,12 +16,20 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
 
         // TODO: Unorganized list of definitions for single-block definitions
         private Dictionary<string, WeaponDefinitionBase> Definitions = new Dictionary<string, WeaponDefinitionBase>(); // TODO: Store serialized versions of definitions in case of modded functionality.
+        private Dictionary<string, byte[]> SerializedDefinitions = new Dictionary<string, byte[]>();
+
 
         public static WeaponDefinitionBase GetDefinition(string subTypeId)
         {
-            //MyLog.Default.WriteLine(subTypeId + " | " + HasDefinition(subTypeId) + " | " + (I.Definitions[subTypeId] == null));
             if (HasDefinition(subTypeId))
                 return I.Definitions[subTypeId];
+            return null;
+        }
+
+        public static byte[] GetSerializedDefinition(string subTypeId)
+        {
+            if (HasDefinition(subTypeId))
+                return I.SerializedDefinitions[subTypeId];
             return null;
         }
 
@@ -29,24 +38,60 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
             return I.Definitions.ContainsKey(subTypeId);
         }
 
+        public static bool UpdateDefinition(byte[] serializedDefinition)
+        {
+            var definition = MyAPIGateway.Utilities.SerializeFromBinary<WeaponDefinitionBase>(serializedDefinition);
+            if (definition == null || !HasDefinition(definition.Assignments.BlockSubtype))
+                return false;
+
+            I.Definitions[definition.Assignments.BlockSubtype] = definition;
+            I.SerializedDefinitions[definition.Assignments.BlockSubtype] = serializedDefinition;
+            return true;
+        }
+
         public static bool UpdateDefinition(WeaponDefinitionBase definition)
         {
             if (!HasDefinition(definition.Assignments.BlockSubtype))
                 return false;
 
             I.Definitions[definition.Assignments.BlockSubtype] = definition;
+            I.SerializedDefinitions[definition.Assignments.BlockSubtype] = MyAPIGateway.Utilities.SerializeToBinary(definition);
             return true;
         }
 
-        public static bool RegisterModApiDefinition(WeaponDefinitionBase definition)
+        public static bool RegisterModApiDefinition(byte[] serializedDefinition)
         {
-            if (HasDefinition(definition.Assignments.BlockSubtype))
+            RegisterDefinition(serializedDefinition);
+            return true; // TODO: Don't always return success
+        }
+
+        public static void RegisterDefinition(byte[] serializedDefinition)
+        {
+            if (serializedDefinition == null)
+                return;
+
+            var definition = MyAPIGateway.Utilities.SerializeFromBinary<WeaponDefinitionBase>(serializedDefinition);
+
+            if (definition == null)
+                return;
+
+            if (I.Definitions.ContainsKey(definition.Assignments.BlockSubtype))
             {
-                SoftHandle.RaiseException("Attempted to assign WeaponDefinition to existing ID!", callingType: typeof(WeaponDefinitionManager));
-                return false;
+                I.Definitions[definition.Assignments.BlockSubtype] = definition;
+                I.SerializedDefinitions[definition.Assignments.BlockSubtype] = serializedDefinition;
+                HeartData.I.Log.Log($"Duplicate weapon definition {definition.Assignments.BlockSubtype}! Overriding...");
             }
-            RegisterDefinition(definition);
-            return true;
+            else
+            {
+                I.Definitions.Add(definition.Assignments.BlockSubtype, definition);
+                I.SerializedDefinitions.Add(definition.Assignments.BlockSubtype, serializedDefinition);
+            }
+
+            HeartData.I.OrreryBlockCategory.AddBlock(definition.Assignments.BlockSubtype);
+            HeartData.I.Log.Log($"Registered weapon definition {definition.Assignments.BlockSubtype}.");
+
+            if (HeartData.I.IsLoaded)
+                WeaponManager.I.UpdateLogicOnExistingBlocks(definition);
         }
 
         public static void RegisterDefinition(WeaponDefinitionBase definition)
@@ -54,19 +99,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
             if (definition == null)
                 return;
 
-            if (I.Definitions.ContainsKey(definition.Assignments.BlockSubtype))
-            {
-                I.Definitions[definition.Assignments.BlockSubtype] = definition;
-                HeartData.I.Log.Log($"Duplicate weapon definition {definition.Assignments.BlockSubtype}! Overriding...");
-            }
-            else
-                I.Definitions.Add(definition.Assignments.BlockSubtype, definition);
-
-            HeartData.I.OrreryBlockCategory.AddBlock(definition.Assignments.BlockSubtype);
-            HeartData.I.Log.Log($"Registered weapon definition {definition.Assignments.BlockSubtype}.");
-
-            if (HeartData.I.IsLoaded)
-                WeaponManager.I.UpdateLogicOnExistingBlocks(definition);
+            RegisterDefinition(MyAPIGateway.Utilities.SerializeToBinary(definition));
         }
 
         public static void RemoveDefinition(string subtype)
@@ -77,6 +110,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
             WeaponDefinitionBase definition = I.Definitions[subtype];
             WeaponManager.I.RemoveLogicOnExistingBlocks(definition);
             I.Definitions.Remove(subtype);
+            I.SerializedDefinitions.Remove(subtype);
 
             HeartData.I.Log.Log("Removed weapon definition " + subtype);
         }

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Weapons/WeaponDefinitionManager.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Weapons/WeaponDefinitionManager.cs
@@ -1,5 +1,6 @@
 ﻿using Heart_Module.Data.Scripts.HeartModule.ErrorHandler;
 using Heart_Module.Data.Scripts.HeartModule.Weapons.StandardClasses;
+using Sandbox.Game.GUI.DebugInputComponents;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,6 +13,7 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
     {
         public static WeaponDefinitionManager I;
 
+        // TODO: Unorganized list of definitions for single-block definitions
         private Dictionary<string, WeaponDefinitionBase> Definitions = new Dictionary<string, WeaponDefinitionBase>(); // TODO: Store serialized versions of definitions in case of modded functionality.
 
         public static WeaponDefinitionBase GetDefinition(string subTypeId)
@@ -65,6 +67,18 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
 
             if (HeartData.I.IsLoaded)
                 WeaponManager.I.UpdateLogicOnExistingBlocks(definition);
+        }
+
+        public static void RemoveDefinition(string subtype)
+        {
+            if (!HasDefinition(subtype))
+                return;
+
+            WeaponDefinitionBase definition = I.Definitions[subtype];
+            WeaponManager.I.RemoveLogicOnExistingBlocks(definition);
+            I.Definitions.Remove(subtype);
+
+            HeartData.I.Log.Log("Removed weapon definition " + subtype);
         }
 
         public static int DefinitionCount()

--- a/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Weapons/WeaponManager.cs
+++ b/Orrery Combat Framework - Heart Module/Data/Scripts/HeartModule/Weapons/WeaponManager.cs
@@ -6,6 +6,7 @@ using VRage.Game.Components;
 using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using YourName.ModName.Data.Scripts.HeartModule.Weapons.Setup.Adding;
+using static VRage.Game.MyObjectBuilder_BehaviorTreeDecoratorNode;
 
 namespace Heart_Module.Data.Scripts.HeartModule.Weapons
 {
@@ -47,6 +48,29 @@ namespace Heart_Module.Data.Scripts.HeartModule.Weapons
                     AddWeapon(block);
                 }
             }
+        }
+
+        /// <summary>
+        /// Removes weapon logic on weapons of a given type
+        /// </summary>
+        /// <param name="definition"></param>
+        public void RemoveLogicOnExistingBlocks(WeaponDefinitionBase definition)
+        {
+            foreach (var grid in GridWeapons)
+            {
+                foreach (var weapon in grid.Value)
+                {
+                    if (weapon.Definition == definition)
+                    {
+                        ActiveWeapons.Remove(weapon.Id);
+                        List<SorterWeaponLogic> values;
+                        GridWeapons.TryGetValue(weapon.SorterWep.CubeGrid, out values);
+                        values?.Remove(weapon);
+
+                        weapon.MarkForClose();
+                    }
+                }
+            }        
         }
 
         /// <summary>

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/DefinitionCollector.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/DefinitionCollector.cs
@@ -1,6 +1,8 @@
 ﻿using OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication.ProjectileBases;
 using OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication.WeaponBases;
 using ProtoBuf;
+using Sandbox.ModAPI;
+using System.Collections.Generic;
 
 namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
 {
@@ -10,10 +12,18 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
 
         internal void LoadWeaponDefinitions(params WeaponDefinitionBase[] defs)
         {
+            List<byte[]> serialWeapons = new List<byte[]>();
+            foreach (var weapon in defs)
+                serialWeapons.Add(MyAPIGateway.Utilities.SerializeToBinary(weapon));
+            Container.SerializedWeaponDefs = serialWeapons.ToArray();
             Container.WeaponDefs = defs;
         }
         internal void LoadAmmoDefinitions(params ProjectileDefinitionBase[] defs)
         {
+            List<byte[]> serialAmmos = new List<byte[]>();
+            foreach (var ammo in defs)
+                serialAmmos.Add(MyAPIGateway.Utilities.SerializeToBinary(ammo));
+            Container.SerializedAmmoDefs = serialAmmos.ToArray();
             Container.AmmoDefs = defs;
         }
 
@@ -31,8 +41,11 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
     internal class DefinitionContainer
     {
         [ProtoMember(1)]
-        public WeaponDefinitionBase[] WeaponDefs { get; set; }
+        public byte[][] SerializedWeaponDefs { get; set; }
         [ProtoMember(2)]
+        public byte[][] SerializedAmmoDefs { get; set; }
+
+        public WeaponDefinitionBase[] WeaponDefs { get; set; }
         public ProjectileDefinitionBase[] AmmoDefs { get; set; }
     }
 }

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/HeartApi.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/HeartApi.cs
@@ -3,8 +3,6 @@ using OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication.WeaponB
 using Sandbox.ModAPI;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using VRage.Game.Entity;
 using VRage.Game.ModAPI;
 using VRage.Utils;

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/HeartApi.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/HeartApi.cs
@@ -71,6 +71,7 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
                     SetApiMethod("GetProjectileDefinition", ref getProjectileDefinition);
                     SetApiMethod("RegisterProjectileDefinition", ref registerProjectileDefinition);
                     SetApiMethod("UpdateProjectileDefinition", ref updateProjectileDefinition);
+                    SetApiMethod("RemoveProjectileDefinition", ref removeProjectileDefinition);
 
                     // Weapon Generics
                     SetApiMethod("BlockHasWeapon", ref blockHasWeapon);
@@ -79,6 +80,7 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
                     SetApiMethod("GetWeaponDefinition", ref getWeaponDefinition);
                     SetApiMethod("RegisterWeaponDefinition", ref registerWeaponDefinition);
                     SetApiMethod("UpdateWeaponDefinition", ref updateWeaponDefinition);
+                    SetApiMethod("RemoveWeaponDefinition", ref removeWeaponDefinition);
 
 
                     HasInited = true;
@@ -158,7 +160,12 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
         private Func<int, byte[], bool> updateProjectileDefinition;
         public static bool UpdateProjectileDefinition(int definitionId, ProjectileDefinitionBase definition) => I?.updateProjectileDefinition?.Invoke(definitionId, MyAPIGateway.Utilities.SerializeToBinary(definition)) ?? false;
 
+        private Action<int> removeProjectileDefinition;
+        public static void RemoveProjectileDefinition(int definitionId) => I?.removeProjectileDefinition?.Invoke(definitionId);
+
         #endregion
+
+        #region Weapons
 
         private Func<MyEntity, bool> blockHasWeapon;
         public static bool BlockHasWeapon(MyEntity block) => I?.blockHasWeapon?.Invoke(block) ?? false;
@@ -207,6 +214,10 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
             return I?.updateWeaponDefinition?.Invoke(serialized) ?? false;
         }
 
+        private Action<string> removeWeaponDefinition;
+        public static void RemoveWeaponDefinition(string definitionType) => I?.removeWeaponDefinition?.Invoke(definitionType);
+
+        #endregion
 
         #region Standard
 

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/ProjectileBases/ProjectileDefinitionBase.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/Communication/ProjectileBases/ProjectileDefinitionBase.cs
@@ -48,6 +48,8 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication.Pro
         /// The item that needs to get consumed for the magazine to reload. Leave blank to not consume anything. The weapon model should probably have a conveyor port.
         /// </summary>
         [ProtoMember(5)] public string MagazineItemToConsume;
+
+        [ProtoMember(6)] public string notsynced; // TODO remove
     }
 
     [ProtoContract]

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/ExampleAmmos.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/ExampleAmmos.cs
@@ -89,16 +89,18 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
             },
             LiveMethods = new LiveMethods()
             {
-                //OnSpawn = (a, b) => {
-                //    HeartApi.RegisterWeaponDefinition(Example2BarrelTurretWeapon);
-                //},
-                //OnImpact = (a, b, c, d) =>
-                //{
-                //    HeartApi.RemoveWeaponDefinition(Example2BarrelTurretWeapon.Assignments.BlockSubtype);
-                //}
+                OnSpawn = (a, b) => {
+                    if (id == 0)
+                        id = HeartApi.RegisterProjectileDefinition(ExampleAmmoMissile);
+                },
+                OnImpact = (a, b, c, d) =>
+                {
+                    HeartApi.LogWriteLine("Checking " + id + " ...");
+                    HeartApi.LogWriteLine(": " + HeartApi.GetProjectileDefinition(id).Ungrouped.notsynced);
+                }
             }
         };
-
+        int id = 0;
         ProjectileDefinitionBase ExampleAmmoMissile => new ProjectileDefinitionBase()
         {
             Name = "ExampleAmmoMissile",
@@ -109,6 +111,7 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
                 Impulse = 5000,
                 ShotsPerMagazine = 10,
                 MagazineItemToConsume = "",
+                notsynced = "my goofy ahh is NOT synced!",
             },
             Damage = new Damage()
             {

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/ExampleAmmos.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/ExampleAmmos.cs
@@ -89,6 +89,13 @@ namespace OrreryFrameworkDemo.Data.Scripts.OrreryFrameworkDemo.Communication
             },
             LiveMethods = new LiveMethods()
             {
+                //OnSpawn = (a, b) => {
+                //    HeartApi.RegisterWeaponDefinition(Example2BarrelTurretWeapon);
+                //},
+                //OnImpact = (a, b, c, d) =>
+                //{
+                //    HeartApi.RemoveWeaponDefinition(Example2BarrelTurretWeapon.Assignments.BlockSubtype);
+                //}
             }
         };
 

--- a/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/HeartDefinitions.cs
+++ b/OrreryFrameworkDemo/Data/Scripts/OrreryFrameworkDemo/HeartDefinitions.cs
@@ -5,7 +5,7 @@
         internal HeartDefinitions()
         {
             LoadWeaponDefinitions(Example2BarrelTurretWeapon, ExampleTurretWeapon, ExampleFixedProjWeapon, ExampleFixedBeamWeapon, ExampleFixedMissileWeapon);         //todo tell the user that they forgot to add stuff here when they get an error
-            LoadAmmoDefinitions(ExampleAmmoProjectile, ExampleAmmoMissile, ExampleAmmoBeam);
+            LoadAmmoDefinitions(ExampleAmmoProjectile, ExampleAmmoBeam);
         }
     }
 }


### PR DESCRIPTION
Definitions are now stored in their serialized form, so values that the HeartMod doesn't keep track of aren't erased.

ex: Torpedo addon wants to add a projectile definition value for how low the torpedo sits in the water.